### PR TITLE
Various Fixes

### DIFF
--- a/docroot/breeze-kendo.js
+++ b/docroot/breeze-kendo.js
@@ -103,7 +103,7 @@
             try {
                 var meta = manager.metadataStore;
                 var typeName = meta.getEntityTypeNameForResourceName(this.query.resourceName);
-                var typeObj = meta.getEntityType(typeName);
+                var typeObj = meta.getEntityType(typeName || this.query.resourceName);
             } catch(ex) {
                 // without metadata Breeze returns plain JS objects
                 // so we can just return the original array.
@@ -156,7 +156,7 @@
             try {
                 var meta = this.manager.metadataStore;
                 var typeName = meta.getEntityTypeNameForResourceName(this.query.resourceName);
-                var typeObj = meta.getEntityType(typeName);
+                var typeObj = meta.getEntityType(typeName || this.query.resourceName);
             } catch(ex) {
                 return schema;
             }
@@ -168,6 +168,7 @@
                     console.error("Multiple-key ID not supported");
                 }
             }
+            
             typeObj.dataProperties.forEach(function(prop){
                 var type = "string";
                 if (prop.dataType.isNumeric) {
@@ -185,6 +186,7 @@
                     nullable     : prop.isNullable,
                 };
             });
+			
             schema.model = model;
             return schema;
         }

--- a/docroot/breeze-kendo.js
+++ b/docroot/breeze-kendo.js
@@ -136,7 +136,7 @@
                     break;
                   case "add":
                     ev.items.forEach(function(item){
-                        var entity = manager.createEntity(typeName || this.query.resourceName, item);
+                        var entity = manager.createEntity(typeName, item);
                         manager.addEntity(entity);
                         syncItems(item, entity);
                     });

--- a/docroot/breeze-kendo.js
+++ b/docroot/breeze-kendo.js
@@ -136,7 +136,7 @@
                     break;
                   case "add":
                     ev.items.forEach(function(item){
-                        var entity = manager.createEntity(typeName, item);
+                        var entity = manager.createEntity(typeName || this.query.resourceName, item);
                         manager.addEntity(entity);
                         syncItems(item, entity);
                     });

--- a/docroot/breeze-kendo.js
+++ b/docroot/breeze-kendo.js
@@ -117,11 +117,29 @@
             // overrun the stack).
 
             var props = typeObj.dataProperties;
+            var navs = typeObj.navigationProperties;
             var a = data.results.map(function(rec){
                 var obj = {};
                 props.forEach(function(prop){
                     obj[prop.name] = rec[prop.name];
                 });
+
+                // handle nav properties - only allows 1 level currently
+                navs.forEach(function(nav) {
+                    var navProps = nav.entityType.dataProperties;
+                    
+                    if (!!rec[nav.name]) {
+                        var navObj = {};
+                        var navRec = rec[nav.name];
+
+                        navProps.forEach(function (navProp) {
+                            navObj[navProp.name] = navRec[navProp.name];
+                        });
+
+                        obj[nav.name] = navObj;
+                    }
+                });
+
                 obj = new kendo.data.Model(obj);
                 syncItems(obj, rec);
                 return obj;
@@ -189,6 +207,23 @@
                         required:      prop.isNullable
                     };
                 });
+                
+                var navs = typeObj.navigationProperties;
+
+                navs.forEach(function(nav) {
+                    var navProps = nav.entityType.dataProperties;
+
+                    /* TODO: Figure out how to map complex properties for the schema...
+                    
+                        Out of the box, Kendo DataSource does not support this in it's schema
+                        An option includes potentially turning all related properties into
+                        Nav_Property instead of Nav.Property, but this would require
+                        Changes to the entirety of the transport to override mapping both
+                        forward and back.
+                    */
+                });
+
+
             } catch (ex) {
                 return schema;
             }


### PR DESCRIPTION
When using the Breeze WebApi2 server plugins, unless using select in
your query definition, metadata and objects were not mapping properly.
Changing the two calls to getEntityType to alternatively use
this.query.resourceName resolved that issue.

Additionally, I've made a variety of other fixes, including making 1st level nav entities available for mapping, fixing manager.rejectChanges so that it updates the kendo model, and ensured that observable objects being returned are kendo models based on the schema, and not just observables.
